### PR TITLE
Update defaults-tr_TR.js

### DIFF
--- a/js/i18n/defaults-tr_TR.js
+++ b/js/i18n/defaults-tr_TR.js
@@ -2,7 +2,7 @@
  * Translated default messages for bootstrap-select.
  * Locale: TR (Turkey)
  * Region: TR (Europe)
- * Author: Serhan Güney
+ * Author: Serhan Güney & Mehmet Emre Kutluca
  */
 (function ($) {
   $.fn.selectpicker.defaults = {
@@ -18,7 +18,7 @@
       ];
     },
     selectAllText: 'Tümünü Seç',
-    deselectAllText: 'Seçiniz',
+    deselectAllText: 'Tüm Seçimleri Kaldır',
     multipleSeparator: ', '
   };
 })(jQuery);


### PR DESCRIPTION
Updated 'deselectAllText' translation to make sure it conveys right message.

Previously, it was 'Seçiniz' which means 'Select', and it was a wrong translation. But now it says 'Tüm Seçimleri Kaldır' which means 'Deselect All' and it is correct now.